### PR TITLE
Add json view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 A small project that allows you to normalize Ecto schemas. Currently,
 two versions are available on Hex. Version 0.1.0 supports Ecto 1.1,
-version 0.2.1 supports the Ecto 2 beta.
+version 0.2.2 supports the Ecto 2 beta.
 
 ## Installation
 
@@ -26,5 +26,5 @@ The package can be installed as:
 
 ## Documentation
 
-All documentation can be found on [Hexdocs](https://hexdocs.pm/normalixr/0.2.1).
+All documentation can be found on [Hexdocs](https://hexdocs.pm/normalixr/0.2.2).
 

--- a/lib/normalixr/name_agent.ex
+++ b/lib/normalixr/name_agent.ex
@@ -1,0 +1,32 @@
+defmodule Normalixr.NameAgent do
+  @moduledoc false
+
+  def start_link(name, default_names) do
+
+    Agent.start_link(fn -> default_names end, name: name)
+  end
+
+  def get(agent, module) do
+    "Elixir." <> mod_name = Atom.to_string(module)
+
+    case Agent.get(agent, &Map.get(&1, mod_name)) do
+      nil ->
+        pascal_case = module
+        |> Module.split
+        |> List.last
+
+        val = ~r/(?<!^)[A-Z](?=[a-z])/
+        |> Regex.replace(pascal_case, "_\\0")
+        |> String.downcase
+        |> String.to_atom
+
+        put(Normalixr.NameAgent, mod_name, val)
+      val -> val
+    end
+  end
+
+  defp put(agent, name, field) do
+    Agent.update(agent, &Map.put(&1, name, field))
+    field
+  end
+end

--- a/lib/normalixr/phoenix_view.ex
+++ b/lib/normalixr/phoenix_view.ex
@@ -94,8 +94,6 @@ defmodule Normalixr.PhoenixView do
       false -> data
       field -> %{field => data}
     end
-
-    %{data: Normalixr.Util.filter_map_into(fields_to_render, filter, mapper)}
   end
   
   defp extract_data_and_opts(assigns) when is_list assigns do

--- a/lib/normalixr/phoenix_view.ex
+++ b/lib/normalixr/phoenix_view.ex
@@ -56,6 +56,13 @@ defmodule Normalixr.PhoenixView do
   If the second option is set to true and the normalized representation 
   contains no models of that type, the field is not rendered. Otherwise, it is
   set to an empty map. By default, it is set to true.
+
+  If you don't want to put the rendered data into a field called data, you
+  must set the following configuration option:
+  config(:normalixr, :data_field, data_field)
+
+  If data_field is set to false, the data will not be put into another map.
+  Otherwise, data is replaced by whatever value is configured.
   """
 
   @spec render(String.t, map) :: map
@@ -79,6 +86,13 @@ defmodule Normalixr.PhoenixView do
 
     mapper = fn({field, opts}) ->
       {field, filter_and_render(field, normalized_data, opts)}
+    end
+
+    data = Normalixr.Util.filter_map_into(fields_to_render, filter, mapper)
+
+    case Application.get_env(:normalixr, :data_field, :data) do
+      false -> data
+      field -> %{field => data}
     end
 
     %{data: Normalixr.Util.filter_map_into(fields_to_render, filter, mapper)}

--- a/lib/normalixr/phoenix_view.ex
+++ b/lib/normalixr/phoenix_view.ex
@@ -119,7 +119,7 @@ defmodule Normalixr.PhoenixView do
           {id, view.render(template, [{field, model}, {:normalized_data, normalized_data}])}
         end
 
-        Normalixr.Util.filter_map_into(normalized_data[field], filter, mapper)
+        Normalixr.Util.filter_map_into(data, filter, mapper)
     end
   end
 end

--- a/lib/normalixr/phoenix_view.ex
+++ b/lib/normalixr/phoenix_view.ex
@@ -38,7 +38,7 @@ defmodule Normalixr.PhoenixView do
       iex> data = Normalixr.normalize(%MyApp.Schemas.City{id: 1})
       ...> assigns = [data: data, fields_to_render: [city: [view: MyApp.CityView]]]
       ...> Normalixr.PhoenixView.render("normalized.json", assigns)
-      %{city: %{1 => %{id: 1}}}
+      %{data: %{city: %{1 => %{id: 1}}}}
   
   You can also set the :except and :only fields in the options. Both these
   fields are anonymous functions which take two argument. The first is a tuple
@@ -81,7 +81,7 @@ defmodule Normalixr.PhoenixView do
       {field, filter_and_render(field, normalized_data, opts)}
     end
 
-    Normalixr.Util.filter_map_into(fields_to_render, filter, mapper)
+    %{data: Normalixr.Util.filter_map_into(fields_to_render, filter, mapper)}
   end
   
   defp extract_data_and_opts(assigns) when is_list assigns do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Normalixr.Mixfile do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.2"
 
   def project do
     [app: :normalixr,
@@ -17,7 +17,8 @@ defmodule Normalixr.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :ecto]]
+    [mod: {Normalixr, []},
+     applications: [:logger, :ecto]]
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]

--- a/test/normalixr/name_agent_test.exs
+++ b/test/normalixr/name_agent_test.exs
@@ -1,0 +1,8 @@
+defmodule Normalixr.NameAgentTest do
+  use ExUnit.Case
+  alias Normalixr.NameAgent
+
+  test "Returns underscored name" do
+    assert NameAgent.get(NameAgent, MyApp.NameTest) == :name_test
+  end
+end

--- a/test/normalixr/phoenix_view_test.exs
+++ b/test/normalixr/phoenix_view_test.exs
@@ -11,7 +11,7 @@ defmodule Normalixr.PhoenixView.Test do
     opts = [data: normalized,
             fields_to_render: [city: [view: MyApp.CityView]]]
 
-    assert Normalixr.PhoenixView.render("normalized.json", opts) === %{city: %{2 => %{id: 2}}}
+    assert Normalixr.PhoenixView.render("normalized.json", opts) === %{data: %{city: %{2 => %{id: 2}}}}
   end
 
   test "rendered template can be changed" do
@@ -21,7 +21,7 @@ defmodule Normalixr.PhoenixView.Test do
     opts = [data: normalized,
             fields_to_render: [city: [view: MyApp.CityView, template: "new_city.json"]]]
 
-    assert Normalixr.PhoenixView.render("normalized.json", opts) === %{city: %{2 => %{id: 12}}}
+    assert Normalixr.PhoenixView.render("normalized.json", opts) === %{data: %{city: %{2 => %{id: 12}}}}
   end
 
   test "models aren't rendered if only returns false" do
@@ -33,7 +33,7 @@ defmodule Normalixr.PhoenixView.Test do
     opts = [data: normalized,
             fields_to_render: [city: [view: MyApp.CityView, only: only]]]
 
-    assert Normalixr.PhoenixView.render("normalized.json", opts) == %{city: %{1 => %{id: 1}}}
+    assert Normalixr.PhoenixView.render("normalized.json", opts) == %{data: %{city: %{1 => %{id: 1}}}}
   end
 
   test "models aren't rendered if except returns true" do
@@ -45,21 +45,21 @@ defmodule Normalixr.PhoenixView.Test do
     opts = [data: normalized,
             fields_to_render: [city: [view: MyApp.CityView, except: except]]]
 
-    assert Normalixr.PhoenixView.render("normalized.json", opts) == %{city: %{1 => %{id: 1}}}
+    assert Normalixr.PhoenixView.render("normalized.json", opts) == %{data: %{city: %{1 => %{id: 1}}}}
   end
 
   test "Field is skipped by default if no data is present" do
     opts = [data: %{},
             fields_to_render: [city: [view: MyApp.CityView]]]
 
-    assert Normalixr.PhoenixView.render("normalized.json", opts) === %{}
+    assert Normalixr.PhoenixView.render("normalized.json", opts) === %{data: %{}}
   end
 
   test "Field is not skipped if dont_render_if_empty is set to false and there is no data" do
     opts = [data: %{},
             fields_to_render: [city: [view: MyApp.CityView, dont_render_if_empty: false]]]
 
-    assert Normalixr.PhoenixView.render("normalized.json", opts) === %{city: %{}}
+    assert Normalixr.PhoenixView.render("normalized.json", opts) === %{data: %{city: %{}
   end
 
   test "NoDataError is raised if raise_if_no_results is set to true and there is no data" do

--- a/test/normalixr/phoenix_view_test.exs
+++ b/test/normalixr/phoenix_view_test.exs
@@ -59,7 +59,7 @@ defmodule Normalixr.PhoenixView.Test do
     opts = [data: %{},
             fields_to_render: [city: [view: MyApp.CityView, dont_render_if_empty: false]]]
 
-    assert Normalixr.PhoenixView.render("normalized.json", opts) === %{data: %{city: %{}
+    assert Normalixr.PhoenixView.render("normalized.json", opts) === %{data: %{city: %{}}}
   end
 
   test "NoDataError is raised if raise_if_no_results is set to true and there is no data" do


### PR DESCRIPTION
This PR adds an agent to cache the names of modules. The return value of rendering function is now wrapped in a map under the key :data by default, but a different value (or no wrapping) can be configured. Similarly, the field names are now configurable.
